### PR TITLE
E: Unable to locate package libopenblas-base を修正

### DIFF
--- a/installscript.toml
+++ b/installscript.toml
@@ -155,7 +155,7 @@ export CHOOSENIM_CHOOSE_VERSION=2.2.2
 curl https://nim-lang.org/choosenim/init.sh -sSf | bash -s -- -y
 export PATH=$HOME/.nimble/bin:$PATH
 nimble install neo -y
-sudo apt install libopenblas-base -y
+sudo apt install libopenblas-dev -y
 nimble install https://github.com/zer0-star/Nim-ACL
 sudo apt install -y libgmp3-dev
 nimble install bignum -y


### PR DESCRIPTION
`libopenblas-dev` を使うといいらしい
参考:
https://stackoverflow.com/questions/36483054/install-openblas-via-apt-get-sudo-apt-get-install-openblas-dev