### PR TITLE
NimVMの制限を緩和

### DIFF
--- a/installscript.toml
+++ b/installscript.toml
@@ -177,7 +177,7 @@ nimble install https://github.com/nim-lang/bigints -y
 #       成功時に後述の object で指定するファイルが生成されるようにコマンドを記述してください
 compile = '''
 export PATH=$HOME/.nimble/bin:$PATH
-nim cpp -d:release --opt:speed --multimethods:on --warning[SmallLshouldNotBeUsed]:off --hints:off -o:a.out Main.nim 
+nim cpp -d:release --opt:speed --multimethods:on --warning[SmallLshouldNotBeUsed]:off --hints:off --maxLoopIterationsVM:10000000000000 --maxCallDepthVM:10000000000000 -o:a.out Main.nim 
 '''
 
 # キー: object


### PR DESCRIPTION
コンパイルコマンドに`--maxLoopIterationsVM:10000000000000`と`--maxCallDepthVM:10000000000000`を追加しました。
https://nim-lang.org/2.2.2/nimc.html
これにより、例えばこのようなコードがコンパイルできるようになります。
```nim
const N = 5_000_000
const primes = block:
  var tab: array[N+1,bool]
  var res = newSeq[int]()
  for i in 2..N:
    if tab[i]: continue
    res.add(i)
    for j in countup(i,N,i): tab[j] = true
  res
echo primes.len

```
これは各自がコード中で`staticExec`等を行いコンパイルさせればよいものというよりはデフォルトのコンパイルコマンドで設定されているべきものと判断し、PRを送ることにしました。