### PR TITLE
regex を追加

### DIFF
--- a/installscript.toml
+++ b/installscript.toml
@@ -114,6 +114,9 @@ library.bigints = { license = [
 library.Arraymancer = { license = [
     { name = 'Apache-2.0', url = 'https://github.com/mratsim/Arraymancer/blob/84af537af1bc1f90229fff2b90abf5e5c1b02616/LICENSE' },
 ], version =  '84af537af1bc1f90229fff2b90abf5e5c1b02616' }
+library.regex = { license = [
+    { name = 'MIT', url = 'https://github.com/nitely/nim-regex/blob/v0.26.3/LICENSE' },
+], version = '0.26.3' }
 library.boost = { license = [
     { name = 'BSL-1.0', url = 'https://www.boost.org/users/license.html' },
 ], version =  '1.88.0' }
@@ -160,6 +163,9 @@ library.stb_image = { license = [
 library.untar = { license = [
     {name = 'MIT', url = 'https://github.com/dom96/untar/blob/master/readme.markdown' },
 ], indirect = true, version = '0.1.0'}
+library.unicodedb = { license = [
+    {name = 'MIT', url = 'https://github.com/nitely/nim-unicodedb/blob/v0.13.2/LICENSE' },
+], indirect = true, version = '0.13.2'}
 
 # キー: filename
 # 型:   文字列
@@ -211,6 +217,7 @@ sudo apt install -y libgmp3-dev
 nimble install bignum@1.0.4 -y
 nimble install https://github.com/nim-lang/bigints -y
 nimble install arraymancer@#84af537af1bc1f90229fff2b90abf5e5c1b02616 -y
+nimble install regex@0.26.3 -y
 sudo apt install -y python3-dev
 wget https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
 tar -xf boost_1_88_0.tar.gz


### PR DESCRIPTION
Pure Nimで記述された正規表現ライブラリ https://github.com/nitely/nim-regex を追加
Nimの標準ライブラリ[re](https://nim-lang.org/docs/re.html)や[nre](https://nim-lang.org/docs/nre.html)では文字数が大きい場合に問題があるのか https://atcoder.jp/contests/abc049/tasks/arc065_a を解こうとするとREになってしまう
このライブラリで記述した以下のコードがNim1系と2系ですべてのシステムテストケースについて高速に期待された出力をすることを確認
```nim
import regex
let S = stdin.readLine()
echo if S.contains(re2"^(dream|dreamer|erase|eraser)+$"): "YES" else: "NO"
```