### PR TITLE
nim-lang/sat を追加

### DIFF
--- a/installscript.toml
+++ b/installscript.toml
@@ -117,6 +117,9 @@ library.Arraymancer = { license = [
 library.regex = { license = [
     { name = 'MIT', url = 'https://github.com/nitely/nim-regex/blob/v0.26.3/LICENSE' },
 ], version = '0.26.3' }
+library.sat = { license = [
+    { name = 'MIT', url = 'https://github.com/nim-lang/sat/blob/faf1617f44d7632ee9601ebc13887644925dcc01/LICENSE' },
+], version = 'faf1617f44d7632ee9601ebc13887644925dcc01' }
 library.boost = { license = [
     { name = 'BSL-1.0', url = 'https://www.boost.org/users/license.html' },
 ], version =  '1.88.0' }
@@ -218,6 +221,7 @@ nimble install https://github.com/chaemon/bignum@0.0.1 -y
 nimble install https://github.com/nim-lang/bigints -y
 nimble install arraymancer@#84af537af1bc1f90229fff2b90abf5e5c1b02616 -y
 nimble install regex@0.26.3 -y
+nimble install https://github.com/nim-lang/sat@#faf1617f44d7632ee9601ebc13887644925dcc01 -y
 sudo apt install -y python3-dev
 wget https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
 tar -xf boost_1_88_0.tar.gz


### PR DESCRIPTION
satソルバのnim-lang/sat を追加
ライブラリはこのように使う(TLEしないことを保証していません)
```nim
# https://atcoder.jp/contests/practice2/tasks/practice2_h
import strutils, sequtils
import sat/[sat, satvars]
let (N, D) = block:
  let S = stdin.readLine.splitWhiteSpace.map(parseInt)
  (S[0],S[1])
when (NimMajor, NimMinor) >= (2,2):
  var X = newSeqUninit[int](N)
  var Y = newSeqUninit[int](N)
else:
  var X = newSeqUninitialized[int](N)
  var Y = newSeqUninitialized[int](N)
for i in 0..<N:
  let S = stdin.readLine.splitWhiteSpace.map(parseInt)
  X[i] = S[0]
  Y[i] = S[1]

var b: Builder
b.openOpr(AndForm)
for i in 0..<N:
  b.openOpr(ExactlyOneOfForm)
  b.add newVar(VarId i)
  b.add newVar(VarId i+N)
  b.closeOpr
for i in 0..<N:
  for j in 0..<N:
    if i == j: continue
    if abs(X[i]-X[j]) < D:
      b.openOpr(ZeroOrOneOfForm)
      b.add newVar(VarId i)
      b.add newVar(VarId j)
      b.closeOpr
    if abs(Y[i]-Y[j]) < D:
      b.openOpr(ZeroOrOneOfForm)
      b.add newVar(VarId i+N)
      b.add newVar(VarId j+N)
      b.closeOpr
b.closeOpr
let f = toForm(b)
var s = createSolution(f)
let res = satisfiable(f,s)
if res:
  stdout.writeLine("Yes")
  for i in 0..<N:
    if s.getVar(VarId(i)) == SetToTrue:
      stdout.writeLine(X[i])
    else: stdout.writeLine(Y[i])
else: stdout.writeLine("No")

```
バージョンが発行されていなかったので最新のcommitを指定
上記コードが1系2系ともにコンパイルできることを確認